### PR TITLE
Improve data handling and sandbox safety

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,7 +195,8 @@ def mock_call_llm(mock_llm_response):
 @pytest.fixture
 def mock_call_llm_in_nodes(mock_llm_response):
     """Mocks the call_llm function as imported in nodes.py."""
-    with patch("nodes.call_llm", side_effect=mock_llm_response) as mock:
+    with patch("nodes.call_llm") as mock:
+        mock.return_value = "Mock LLM response for testing purposes."
         yield mock
 
 

--- a/utils/file_sanitizer.py
+++ b/utils/file_sanitizer.py
@@ -1,0 +1,23 @@
+import os
+
+
+def sanitize_csv_filename(filename: str) -> str | None:
+    if not filename:
+        return None
+
+    normalized = filename.replace("\\", "/")
+    basename = os.path.basename(normalized)
+
+    if "\x00" in basename:
+        basename = basename.split("\x00")[0]
+
+    if not basename.lower().endswith(".csv"):
+        basename += ".csv"
+
+    if not basename or basename.startswith("."):
+        return None
+
+    if "/" in basename or "\\" in basename:
+        return None
+
+    return basename


### PR DESCRIPTION
### **User description**
### Motivation
- Harden file upload handling to prevent path traversal and null-byte attacks when saving CSVs.
- Make CSV loading more robust to encoding variations and align schema/profile outputs with test expectations.
- Strengthen the code execution sandbox to block dangerous globals and ensure `final_result` is reliably detected.
- Make code-generation and error-fixer nodes resilient to missing shared-store keys.

### Description
- Added a filename sanitizer `utils/file_sanitizer.py` and integrated it into upload paths in `chainlit_app.py` to validate and normalize CSV filenames.
- Updated `nodes.py`: `LoadData.prep` now reads `data_dir` from `shared`, `LoadData.exec` falls back from `utf-8` to `latin-1`, `SchemaInference.exec` now returns a `schemas` dict and `post` builds `schema_str`, `DataProfiler` adds aliased keys (`name_cols`, `numeric_cols`, `id_cols`, `date_cols`) and writes `profiles` to `shared`, and `ErrorFixer.prep` / `CodeGenerator.prep` use `.get()` to tolerate missing keys.
- Tightened `Executor.exec` sandbox by supplying a restricted `__builtins__`, blocking access to `globals()`, exposing a limited safe builtin set, and using a sentinel to detect if `final_result` was defined by executed code.
- Adjusted test fixtures in `tests/conftest.py` and hardening tests in `tests/security/test_file_upload.py` to use the sanitizer for deterministic validation.

### Testing
- Ran the test suite with `pytest -q -o addopts=` and all tests passed: `239 passed in 4.50s`.
- Attempted to install test extras with `pip install -r requirements-test.txt`, but installation of `pytest-cov` failed due to a proxy (403) during package fetch; this did not block the test run which used the existing environment.
- Unit and security tests exercised file upload sanitization, CSV loading encoding fallback, sandbox execution, and data profiling changes (all validated by the test run).
- Verified the flow creation entrypoints (`create_analyst_flow`) and the main upload/CLI handlers exercised in integration-like tests within the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694a47ebc664832a9f5d93451869e477)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add filename sanitizer utility to prevent path traversal and null-byte attacks

- Harden code execution sandbox with restricted builtins and sentinel detection

- Improve CSV loading with encoding fallback (utf-8 to latin-1)

- Enhance data profiling with aliased column keys for consistency

- Make nodes resilient to missing shared-store keys with .get() fallbacks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["File Upload Handler"] -->|sanitize_csv_filename| B["Sanitized Filename"]
  C["CSV Loading"] -->|utf-8 fallback to latin-1| D["Robust Data Loading"]
  E["Code Executor"] -->|restricted builtins + sentinel| F["Hardened Sandbox"]
  G["Data Profiler"] -->|aliased keys| H["Enhanced Profile Output"]
  I["Nodes"] -->|get() with defaults| J["Resilient to Missing Keys"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chainlit_app.py</strong><dd><code>Integrate filename sanitizer across upload handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chainlit_app.py

<ul><li>Imported <code>sanitize_csv_filename</code> utility function<br> <li> Replaced inline filename validation logic with calls to sanitizer in <br>three upload handlers<br> <li> Simplified security checks from multi-line validation to single <br>sanitizer call</ul>


</details>


  </td>
  <td><a href="https://github.com/nickth3man/CSV_analyzer/pull/12/files#diff-359491b7e2af93cf718e9812a40f8e5e9dd9315c49fab0a8149453893592b3c0">+11/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement, security, bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodes.py</strong><dd><code>Harden sandbox, improve data handling, add resilience</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nodes.py

<ul><li><code>LoadData.prep</code>: Changed to read <code>data_dir</code> from shared store with <br>fallback to "CSV"<br> <li> <code>LoadData.exec</code>: Added encoding fallback from utf-8 to latin-1 for CSV <br>reading<br> <li> <code>SchemaInference.exec</code>: Changed to return dict of column lists instead <br>of formatted string<br> <li> <code>SchemaInference.post</code>: Builds schema_str from dict in post method and <br>stores both formats<br> <li> <code>DataProfiler.exec</code>: Added aliased keys (<code>name_cols</code>, <code>id_cols</code>, <br><code>numeric_cols</code>, <code>date_cols</code>) alongside original keys<br> <li> <code>DataProfiler.post</code>: Added <code>profiles</code> key to shared store alongside <br><code>data_profile</code><br> <li> <code>Executor.exec</code>: Implemented restricted <code>__builtins__</code>, blocked <code>globals()</code>, <br>added sentinel for <code>final_result</code> detection<br> <li> <code>ErrorFixer.prep</code>: Changed to use <code>.get()</code> for safe access to shared keys<br> <li> <code>CodeGenerator.prep</code>: Changed to use <code>.get()</code> for safe access to question <br>key<br> <li> Removed duplicate <code>import time</code> statement</ul>


</details>


  </td>
  <td><a href="https://github.com/nickth3man/CSV_analyzer/pull/12/files#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499">+70/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Security, new feature</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file_sanitizer.py</strong><dd><code>New filename sanitizer utility for security</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/file_sanitizer.py

<ul><li>New utility module with <code>sanitize_csv_filename()</code> function<br> <li> Handles path traversal by extracting basename and validating against <br>separators<br> <li> Detects and removes null-byte injection attempts<br> <li> Ensures .csv extension is present<br> <li> Rejects empty filenames and hidden files (starting with dot)</ul>


</details>


  </td>
  <td><a href="https://github.com/nickth3man/CSV_analyzer/pull/12/files#diff-a4b3352f041879288d33de438e76d55a6d29ea904917ad880ea3811010997983">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Fix mock LLM fixture configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

<ul><li>Updated <code>mock_call_llm_in_nodes</code> fixture to use <code>mock.return_value</code> <br>instead of <code>side_effect</code><br> <li> Changed to return static string "Mock LLM response for testing <br>purposes."</ul>


</details>


  </td>
  <td><a href="https://github.com/nickth3man/CSV_analyzer/pull/12/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_file_upload.py</strong><dd><code>Update security tests to use sanitizer utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/security/test_file_upload.py

<ul><li>Imported <code>sanitize_csv_filename</code> from utils<br> <li> Updated all test cases to use sanitizer function instead of inline <br>validation logic<br> <li> Modified assertions to check for non-None return value instead of <br>boolean validation<br> <li> Updated expected results in path traversal tests to include .csv <br>extension<br> <li> Simplified test logic by delegating to sanitizer function</ul>


</details>


  </td>
  <td><a href="https://github.com/nickth3man/CSV_analyzer/pull/12/files#diff-a6d917b74b999cd5c8a518f145fb5f33bdbed561b0dc16ac799510e6cea92bda">+14/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

