### PR TITLE
Add NBA API dual-source scaffolding

### DIFF
--- a/flow.py
+++ b/flow.py
@@ -1,10 +1,26 @@
 from pocketflow import Flow
 from nodes import (
-    LoadData, SchemaInference, DataProfiler,
-    ClarifyQuery, AskUser, EntityResolver, SearchExpander,
-    ContextAggregator, Planner,
-    CodeGenerator, SafetyCheck, Executor, ErrorFixer,
-    ResultValidator, DeepAnalyzer, Visualizer, ResponseSynthesizer
+    LoadData,
+    NBAApiDataLoader,
+    DataMerger,
+    SchemaInference,
+    DataProfiler,
+    ClarifyQuery,
+    AskUser,
+    EntityResolver,
+    SearchExpander,
+    ContextAggregator,
+    Planner,
+    CodeGenerator,
+    NBAApiCodeGenerator,
+    SafetyCheck,
+    Executor,
+    ErrorFixer,
+    ResultValidator,
+    CrossValidator,
+    DeepAnalyzer,
+    Visualizer,
+    ResponseSynthesizer,
 )
 
 def create_analyst_flow():
@@ -15,6 +31,8 @@ def create_analyst_flow():
     """
 
     load = LoadData()
+    nba_loader = NBAApiDataLoader()
+    merger = DataMerger()
     schema = SchemaInference()
     profiler = DataProfiler()
     clarify = ClarifyQuery()
@@ -25,39 +43,40 @@ def create_analyst_flow():
     plan = Planner()
 
     code_gen = CodeGenerator()
+    api_code_gen = NBAApiCodeGenerator()
     safety = SafetyCheck()
     executor = Executor()
     fixer = ErrorFixer()
 
     result_validator = ResultValidator()
+    cross_validator = CrossValidator()
     deep_analyzer = DeepAnalyzer()
     viz = Visualizer()
     synthesizer = ResponseSynthesizer()
 
-    load - "default" >> schema
+    load - "default" >> nba_loader
     load - "no_data" >> ask_user
+    nba_loader >> merger >> schema
     schema >> profiler >> clarify
 
     clarify - "ambiguous" >> ask_user
-    clarify - "clear"     >> entity_resolver
+    clarify - "clear" >> entity_resolver
 
     # AskUser can re-enter the flow with a clarified question (CLI mode)
     ask_user - "clarified" >> entity_resolver
     # Other AskUser actions ("default", "quit") terminate the flow
 
-    entity_resolver >> search_expander >> context_aggregator >> plan >> code_gen
-
-    code_gen >> safety
+    entity_resolver >> search_expander >> context_aggregator >> plan >> code_gen >> api_code_gen >> safety
 
     safety - "unsafe" >> code_gen
-    safety - "safe"   >> executor
+    safety - "safe" >> executor
 
-    executor - "error"   >> fixer
-    fixer    - "fix"     >> code_gen
-    fixer    - "give_up" >> synthesizer
+    executor - "error" >> fixer
+    fixer - "fix" >> code_gen
+    fixer - "give_up" >> synthesizer
     executor - "success" >> result_validator
 
-    result_validator >> deep_analyzer >> viz >> synthesizer
+    result_validator >> cross_validator >> deep_analyzer >> viz >> synthesizer
 
     return Flow(start=load)
 

--- a/utils/data_source_manager.py
+++ b/utils/data_source_manager.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+
+class DataSourceManager:
+    """Coordinates CSV + NBA API dataframes and resolves conflicts."""
+
+    DISCREPANCY_THRESHOLD = 0.05
+
+    def detect_query_entities(self, question: str) -> List[str]:
+        """Lightweight entity detection to inform API endpoint choices."""
+        if not question:
+            return []
+        candidates = re.findall(r"[A-Z][a-z]+(?:\s[A-Z][a-z]+)*", question)
+        seen: List[str] = []
+        for candidate in candidates:
+            if candidate not in seen:
+                seen.append(candidate)
+        return seen
+
+    def determine_api_endpoints(self, entities: List[str], question: str) -> List[Dict[str, Any]]:
+        """Map entities + intent to candidate endpoints."""
+        endpoints: List[Dict[str, Any]] = []
+        q_lower = question.lower()
+
+        def add_endpoint(name: str, params: Optional[Dict[str, Any]] = None):
+            endpoints.append({"name": name, "params": params or {}})
+
+        if "score" in q_lower or "today" in q_lower or "live" in q_lower:
+            add_endpoint("scoreboard", {})
+
+        if any(k in q_lower for k in ["compare", "versus", "vs", "better", "greater"]):
+            for ent in entities:
+                add_endpoint("player_career", {"entity": ent})
+                add_endpoint("league_leaders", {"entity": ent})
+
+        if "lineup" in q_lower or "roster" in q_lower:
+            for ent in entities:
+                add_endpoint("common_team_roster", {"entity": ent})
+
+        if "game log" in q_lower or "recent games" in q_lower:
+            for ent in entities:
+                add_endpoint("player_game_log", {"entity": ent})
+
+        if not endpoints:
+            for ent in entities:
+                add_endpoint("player_career", {"entity": ent})
+
+        return endpoints
+
+    def merge_data_sources(
+        self, csv_data: Dict[str, pd.DataFrame], api_data: Dict[str, pd.DataFrame]
+    ) -> Tuple[Dict[str, pd.DataFrame], List[Dict[str, Any]], Dict[str, str]]:
+        """Merge CSV + API dataframes with source tracking and discrepancies."""
+        merged: Dict[str, pd.DataFrame] = {}
+        discrepancies: List[Dict[str, Any]] = []
+        sources: Dict[str, str] = {}
+
+        csv_data = csv_data or {}
+        api_data = api_data or {}
+
+        for name, df in csv_data.items():
+            merged[name] = df.copy()
+            merged[name]["_source"] = "csv"
+            sources[name] = "csv"
+
+        for name, df in api_data.items():
+            if name in merged:
+                merged_df, table_discrepancies = self._merge_table(merged[name], df, name)
+                merged[name] = merged_df
+                discrepancies.extend(table_discrepancies)
+                sources[name] = "merged"
+            else:
+                merged[name] = df.copy()
+                merged[name]["_source"] = "api"
+                sources[name] = "api"
+
+        return merged, discrepancies, sources
+
+    def _merge_table(
+        self, csv_df: pd.DataFrame, api_df: pd.DataFrame, table_name: str
+    ) -> Tuple[pd.DataFrame, List[Dict[str, Any]]]:
+        """Merge a single table and record discrepancies."""
+        discrepancies: List[Dict[str, Any]] = []
+        working_api_df = api_df.copy()
+        working_csv_df = csv_df.copy()
+
+        if "_source" not in working_api_df.columns:
+            working_api_df["_source"] = "api"
+        if "_source" not in working_csv_df.columns:
+            working_csv_df["_source"] = "csv"
+
+        common_keys = [
+            key
+            for key in ["PLAYER_ID", "PERSON_ID", "TEAM_ID"]
+            if key in working_api_df.columns and key in working_csv_df.columns
+        ]
+        if common_keys:
+            key = common_keys[0]
+            merged = working_csv_df.merge(
+                working_api_df, on=key, how="outer", suffixes=("_csv", "_api")
+            )
+            numeric_cols = [c for c in merged.columns if pd.api.types.is_numeric_dtype(merged[c])]
+            for col in numeric_cols:
+                if col.endswith("_csv"):
+                    base = col[:-4]
+                    api_col = f"{base}_api"
+                    if api_col in merged.columns:
+                        merged[base] = merged[api_col].combine_first(merged[col])
+                        diff = (merged[col] - merged[api_col]).abs()
+                        denom = merged[api_col].replace(0, pd.NA)
+                        diff_pct = (diff / denom).fillna(0)
+                        flagged = diff_pct > self.DISCREPANCY_THRESHOLD
+                        if flagged.any():
+                            for _, row in merged[flagged][[col, api_col]].iterrows():
+                                discrepancies.append(
+                                    {
+                                        "table": table_name,
+                                        "field": base,
+                                        "csv": row[col],
+                                        "api": row[api_col],
+                                        "diff_pct": float(
+                                            abs(row[col] - row[api_col]) / row[api_col]
+                                        )
+                                        if row[api_col] not in (0, None, pd.NA)
+                                        else 0.0,
+                                    }
+                                )
+        else:
+            merged = pd.concat([working_api_df, working_csv_df], ignore_index=True, sort=False)
+
+        merged["_source"] = merged.get("_source_api", merged.get("_source_csv", "merged"))
+        merged.drop(
+            columns=[c for c in merged.columns if c.startswith("_source_")],
+            inplace=True,
+            errors="ignore",
+        )
+        return merged, discrepancies
+
+    def reconcile_conflicts(self, csv_value: Any, api_value: Any, field: str) -> Tuple[Any, str]:
+        """Resolve conflicts according to priority rules."""
+        if api_value is None and csv_value is None:
+            return None, "missing"
+        if api_value is None:
+            return csv_value, "csv"
+        if csv_value is None:
+            return api_value, "api"
+
+        try:
+            csv_float = float(csv_value)
+            api_float = float(api_value)
+            if api_float == 0:
+                return (csv_value, "csv") if csv_value else (api_value, "api")
+            diff_pct = abs(csv_float - api_float) / abs(api_float)
+            if diff_pct <= self.DISCREPANCY_THRESHOLD:
+                return api_value, "api"
+            return (api_value, "api") if "current" in field.lower() else (csv_value, "csv")
+        except (TypeError, ValueError):
+            return api_value, "api"
+
+
+data_source_manager = DataSourceManager()

--- a/utils/nba_api_client.py
+++ b/utils/nba_api_client.py
@@ -1,0 +1,175 @@
+import hashlib
+import json
+import os
+import threading
+import time
+
+import pandas as pd
+from nba_api.live.nba.endpoints import scoreboard
+from nba_api.stats import endpoints
+from nba_api.stats.static import players, teams
+
+
+class NBAApiClient:
+    """Lightweight wrapper around nba_api with caching and rate limiting."""
+
+    def __init__(self):
+        self.request_delay = float(os.environ.get("NBA_API_REQUEST_DELAY", 0.6))
+        self.cache_ttl = int(os.environ.get("NBA_API_CACHE_TTL", 3600))
+        self.cache_dir = os.environ.get("NBA_API_CACHE_DIR", ".nba_cache")
+        os.makedirs(self.cache_dir, exist_ok=True)
+
+        self._lock = threading.Lock()
+        self._last_request_time = 0.0
+
+    # -------------------------
+    # Internal helpers
+    # -------------------------
+    def _serialize(self, payload):
+        if isinstance(payload, pd.DataFrame):
+            return {
+                "__type": "dataframe",
+                "columns": list(payload.columns),
+                "data": payload.to_dict(orient="records"),
+            }
+        if isinstance(payload, dict):
+            return {k: self._serialize(v) for k, v in payload.items()}
+        if isinstance(payload, list):
+            return [self._serialize(v) for v in payload]
+        return payload
+
+    def _deserialize(self, payload):
+        if isinstance(payload, dict) and payload.get("__type") == "dataframe":
+            return pd.DataFrame(payload.get("data", []), columns=payload.get("columns", []))
+        if isinstance(payload, dict):
+            return {k: self._deserialize(v) for k, v in payload.items()}
+        if isinstance(payload, list):
+            return [self._deserialize(v) for v in payload]
+        return payload
+
+    def _cache_path(self, name, params):
+        key_str = json.dumps({"name": name, "params": params}, sort_keys=True, default=str)
+        hashed = hashlib.sha256(key_str.encode("utf-8")).hexdigest()
+        return os.path.join(self.cache_dir, f"{name}_{hashed}.json")
+
+    def _read_cache(self, name, params):
+        path = self._cache_path(name, params)
+        if not os.path.exists(path):
+            return None
+        with open(path, "r", encoding="utf-8") as f:
+            cached = json.load(f)
+        timestamp = cached.get("timestamp", 0)
+        if time.time() - timestamp > self.cache_ttl:
+            return None
+        return self._deserialize(cached.get("payload"))
+
+    def _write_cache(self, name, params, payload):
+        path = self._cache_path(name, params)
+        os.makedirs(self.cache_dir, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"timestamp": time.time(), "payload": self._serialize(payload)}, f)
+
+    def _throttle(self):
+        with self._lock:
+            elapsed = time.time() - self._last_request_time
+            if elapsed < self.request_delay:
+                time.sleep(self.request_delay - elapsed)
+            self._last_request_time = time.time()
+
+    def _call_with_cache(self, name, params, fetch_fn, cacheable=True):
+        if cacheable:
+            cached = self._read_cache(name, params)
+            if cached is not None:
+                return cached
+
+        self._throttle()
+        result = fetch_fn()
+
+        if cacheable:
+            self._write_cache(name, params, result)
+        return result
+
+    # -------------------------
+    # Static data helpers (no HTTP)
+    # -------------------------
+    def get_all_players(self):
+        return players.get_players()
+
+    def get_active_players(self):
+        return players.get_active_players()
+
+    def find_player(self, name):
+        matches = players.find_players_by_full_name(name)
+        return matches[0] if matches else None
+
+    def get_player_id(self, name):
+        player = self.find_player(name)
+        return player.get("id") if player else None
+
+    def get_all_teams(self):
+        return teams.get_teams()
+
+    def find_team(self, name):
+        normalized = name.lower()
+        by_abbr = teams.find_team_by_abbreviation(name.upper())
+        if by_abbr:
+            return by_abbr
+
+        city_matches = teams.find_teams_by_city(name)
+        if city_matches:
+            return city_matches[0]
+
+        for team in self.get_all_teams():
+            if team["full_name"].lower() == normalized or team["nickname"].lower() == normalized:
+                return team
+        return None
+
+    # -------------------------
+    # Stats endpoints (HTTP)
+    # -------------------------
+    def get_player_career_stats(self, player_id):
+        def fetch():
+            frames = endpoints.PlayerCareerStats(player_id=player_id).get_data_frames()
+            keys = ["regular_season", "post_season", "career_regular", "career_post"]
+            return {k: frames[i] if i < len(frames) else pd.DataFrame() for i, k in enumerate(keys)}
+
+        return self._call_with_cache("player_career_stats", {"player_id": player_id}, fetch)
+
+    def get_player_game_log(self, player_id, season):
+        def fetch():
+            frame = endpoints.PlayerGameLog(player_id=player_id, season=season).get_data_frames()[0]
+            return frame
+
+        return self._call_with_cache("player_game_log", {"player_id": player_id, "season": season}, fetch)
+
+    def get_team_game_log(self, team_id, season):
+        def fetch():
+            frame = endpoints.TeamGameLog(team_id=team_id, season=season).get_data_frames()[0]
+            return frame
+
+        return self._call_with_cache("team_game_log", {"team_id": team_id, "season": season}, fetch)
+
+    def get_league_leaders(self, season, stat_category="PTS"):
+        def fetch():
+            frame = endpoints.LeagueLeaders(season=season, stat_category_abbreviation=stat_category).get_data_frames()[0]
+            return frame
+
+        return self._call_with_cache("league_leaders", {"season": season, "stat_category": stat_category}, fetch)
+
+    def get_common_team_roster(self, team_id, season):
+        def fetch():
+            frame = endpoints.CommonTeamRoster(team_id=team_id, season=season).get_data_frames()[0]
+            return frame
+
+        return self._call_with_cache("common_team_roster", {"team_id": team_id, "season": season}, fetch)
+
+    def get_scoreboard(self):
+        # Live endpoint - do not cache
+        self._throttle()
+        board = scoreboard.ScoreBoard().get_dict()
+        games = board.get("scoreboard", {}).get("games", [])
+        return pd.DataFrame(games)
+
+
+nba_client = NBAApiClient()
+


### PR DESCRIPTION
## Summary
- add a cached, rate-limited nba_api client plus data source manager for merging CSV and API frames
- extend nodes with NBA API data loading, merging, dual code generation, and cross-validation support
- rewire the analyst flow to run CSV and API pipelines before validation and analysis

## Testing
- python -m compileall utils nodes.py flow.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694b70d2d9a4832a910e238bc4817104)

## Summary by Sourcery

Integrate NBA API as a second data source alongside CSVs and update the analyst flow to load, merge, analyze, and cross-validate both sources end-to-end.

New Features:
- Introduce an NBA API client with caching, rate limiting, and helper methods for common endpoints.
- Add nodes to load NBA API data, merge CSV and API dataframes, generate NBA API-specific analysis code, and cross-validate CSV vs API results.
- Extend the analyst flow to run dual pipelines (CSV and NBA API), including separate code generation and execution paths.

Enhancements:
- Track data provenance and discrepancies across CSV and API tables and expose this metadata in schema and context summaries.
- Augment planning, entity resolution, and deep analysis prompts with entity IDs, data source information, and cross-validation context.
- Update safety checks and execution to handle and validate separate CSV and NBA API code snippets with distinct timeouts.